### PR TITLE
Clean translation folders for each run to avoid conflicts with existing translations

### DIFF
--- a/src/translators/project_translator.py
+++ b/src/translators/project_translator.py
@@ -1,5 +1,4 @@
 import logging
-import shutil
 from pathlib import Path
 import asyncio
 from semantic_kernel import Kernel

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -166,3 +166,31 @@ def filter_files(directory: str | Path) -> list:
     """
     directory = Path(directory)
     return [file for file in directory.glob('**/*') if file.is_file()]
+
+def reset_translation_directories(translations_dir: Path, image_dir: Path, language_codes: list):
+    """
+    Remove existing translation and translated_images directories if they exist,
+    and then create new ones.
+    
+    Args:
+        translations_dir (Path): The directory where translations are stored.
+        image_dir (Path): The directory where translated images are stored.
+        language_codes (list): A list of language codes for creating language-specific directories.
+    """
+    # Remove existing directories
+    if translations_dir.exists():
+        shutil.rmtree(translations_dir)
+        logger.info(f"Removed existing translations directory: {translations_dir}")
+    
+    if image_dir.exists():
+        shutil.rmtree(image_dir)
+        logger.info(f"Removed existing translated_images directory: {image_dir}")
+
+    # Create new directories
+    for lang_code in language_codes:
+        lang_dir = translations_dir / lang_code
+        lang_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"Created directory for {lang_code}: {lang_dir}")
+    
+    image_dir.mkdir(parents=True, exist_ok=True)
+    logger.info(f"Created translated_images directory: {image_dir}")


### PR DESCRIPTION
This PR addresses the issue of conflicts with existing translations by ensuring that the `translations` and `translated_images` directories are cleaned before each run. The following changes were made:

- **Implemented folder cleanup**: The existing `translations` and `translated_images` directories are now removed before starting each translation run to prevent conflicts with previously generated files.
- **Modularized folder reset functionality**: Moved the directory reset logic to `file_utils.py` for better modularity and reusability.
- Ensured that new translation directories are created after the old ones are removed.

These changes ensure that each translation run starts with a clean slate, improving reliability and preventing any issues caused by leftover files from previous runs.

---

Solved #8 