### PR TITLE
Enable `translate - "all"` and Enhancements for Language Code Handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "co_op_translator"
-version = "0.1.2"
+version = "0.1.3"
 description = "Easily automate multilingual translations for your projects with co-op-translator, powered by advanced LLM technology."
 authors = ["Minseok Song <skytin1004@gmail.com>"]
 maintainers = [

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -5,7 +5,7 @@ import yaml
 from co_op_translator.translators.project_translator import ProjectTranslator
 
 @click.command()
-@click.option('--language-codes', '-l', required=True, help='Space-separated language codes for translation (e.g., "es fr de").')
+@click.option('--language-codes', '-l', required=True, help='Space-separated language codes for translation (e.g., "es fr de" or "all").')
 @click.option('--root-dir', '-r', default='.', help='Root directory of the project (default is current directory).')
 @click.option('--debug', is_flag=True, help='Enable debug mode (default is INFO level, set to DEBUG if enabled).')
 def main(language_codes, root_dir, debug):
@@ -31,7 +31,7 @@ def main(language_codes, root_dir, debug):
     else:
         logging.basicConfig(level=logging.CRITICAL)
 
-    # If 'all' is passed, load all language codes from the font mapping file
+    # If 'all' is passed for language_codes, load all available language codes from the font mapping file
     if language_codes == "all":
         with importlib.resources.path('co_op_translator.fonts', 'font_language_mappings.yml') as mappings_path:
             with open(mappings_path, 'r', encoding='utf-8') as file:

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -36,7 +36,8 @@ def main(language_codes, root_dir, debug):
         with importlib.resources.path('co_op_translator.fonts', 'font_language_mappings.yml') as mappings_path:
             with open(mappings_path, 'r', encoding='utf-8') as file:
                 font_mappings = yaml.safe_load(file)
-                language_codes = " ".join(font_mappings.keys())  # Use all keys (languages) from the font mapping file
+                # Only extract the top-level language codes (e.g., 'ar', 'en', 'fr', etc.)
+                language_codes = " ".join([lang_code for lang_code in font_mappings if isinstance(font_mappings[lang_code], dict)])
                 logging.debug(f"Loaded language codes from font mapping: {language_codes}")
     
     # Initialize the ProjectTranslator

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -47,13 +47,5 @@ def main(language_codes, root_dir, debug):
 
     click.echo(f"Project translation completed for languages: {language_codes}")
 
-    # Initialize the ProjectTranslator
-    translator = ProjectTranslator(language_codes, root_dir)
-    
-    # Translate the project
-    translator.translate_project()
-
-    click.echo(f"Project translation completed for languages: {language_codes}")
-
 if __name__ == '__main__':
     main()

--- a/src/co_op_translator/__main__.py
+++ b/src/co_op_translator/__main__.py
@@ -1,5 +1,7 @@
 import logging
 import click
+import importlib.resources
+import yaml
 from co_op_translator.translators.project_translator import ProjectTranslator
 
 @click.command()
@@ -28,6 +30,22 @@ def main(language_codes, root_dir, debug):
         logging.debug("Debug mode enabled.")
     else:
         logging.basicConfig(level=logging.CRITICAL)
+
+    # If 'all' is passed, load all language codes from the font mapping file
+    if language_codes == "all":
+        with importlib.resources.path('co_op_translator.fonts', 'font_language_mappings.yml') as mappings_path:
+            with open(mappings_path, 'r', encoding='utf-8') as file:
+                font_mappings = yaml.safe_load(file)
+                language_codes = " ".join(font_mappings.keys())  # Use all keys (languages) from the font mapping file
+                logging.debug(f"Loaded language codes from font mapping: {language_codes}")
+    
+    # Initialize the ProjectTranslator
+    translator = ProjectTranslator(language_codes, root_dir)
+    
+    # Translate the project
+    translator.translate_project()
+
+    click.echo(f"Project translation completed for languages: {language_codes}")
 
     # Initialize the ProjectTranslator
     translator = ProjectTranslator(language_codes, root_dir)

--- a/src/co_op_translator/fonts/font_language_mappings.yml
+++ b/src/co_op_translator/fonts/font_language_mappings.yml
@@ -82,7 +82,7 @@ sv:
 da:
   name: "Danish"
   font: "NotoSans-Medium.ttf"
-no:
+"no":
   name: "Norwegian"
   font: "NotoSans-Medium.ttf"
 fi:


### PR DESCRIPTION
## Enable `translate - "all"` and Enhancements for Language Code Handling

### Changes:
1. **Version Bump**:
   - Updated the version in `pyproject.toml` from `0.1.2` to `0.1.3`.

2. **Main CLI Improvements**:
   - Added support for the `all` keyword in the `--language-codes` option:
     - When `all` is passed, the CLI now dynamically loads all available language codes from the `font_language_mappings.yml` file. 
     - This makes it easier to apply translation for all supported languages without manually listing each language code.
   - Included logic to extract top-level language codes (e.g., `ar`, `en`, `fr`, etc.) from the font mappings file.
   - Debug messages are logged to provide insight into the loaded language codes when debug mode is enabled.

3. **Fix in Font Language Mappings**:
   - Fixed an issue with the Norwegian language code, correcting `"no"` to `no` in `font_language_mappings.yml`.
