### PR TITLE
Optimize translation process with task batching and flexible CLI modes

### DIFF
--- a/src/co_op_translator/config/constants.py
+++ b/src/co_op_translator/config/constants.py
@@ -1,5 +1,5 @@
 SUPPORTED_IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg'}
 EXCLUDED_DIRS = {
-    '.git', '.github', '.vscode', '__pycache__', 'node_modules', 'build', 'dist', 'venv',
+    'translations', 'translated_images' ,'.git', '.github', '.vscode', '__pycache__', 'node_modules', 'build', 'dist', 'venv',
     'env', 'site-packages', '.venv', '.idea', '.devcontainer', '.pytest_cache'
 }

--- a/src/co_op_translator/translators/project_translator.py
+++ b/src/co_op_translator/translators/project_translator.py
@@ -2,12 +2,13 @@ import logging
 import os
 from pathlib import Path
 import asyncio
+from tqdm.asyncio import tqdm_asyncio
 from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai.open_ai import AzureChatCompletion
 from co_op_translator.translators import text_translator, image_translator, markdown_translator
 from co_op_translator.config.base_config import Config
 from co_op_translator.config.constants import SUPPORTED_IMAGE_EXTENSIONS, EXCLUDED_DIRS
-from co_op_translator.utils.file_utils import read_input_file, handle_empty_document, get_filename_and_extension, filter_files, reset_translation_directories
+from co_op_translator.utils.file_utils import read_input_file, handle_empty_document, get_filename_and_extension, filter_files, reset_translation_directories, generate_translated_filename, delete_translated_images_by_language_code, delete_translated_markdown_files_by_language_code
 
 logger = logging.getLogger(__name__)
 
@@ -82,48 +83,131 @@ class ProjectTranslator:
         except Exception as e:
             logger.error(f"Failed to translate {file_path}: {e}")
 
-    async def process_all_markdown_files(self):
+    async def translate_all_markdown_files(self, update=False):
         """
-        Process and translate all markdown files in the project directory.
+        Handles the markdown translation process. If update is True, it cleans the existing translated files
+        before processing the markdown files. If update is False, it skips translating markdown files that already exist.
         """
-        tasks = []
-        markdown_files = filter_files(self.root_dir, EXCLUDED_DIRS)
-        for md_file_path in markdown_files:
-            if md_file_path.suffix == '.md':
-                md_file_path = md_file_path.resolve()
-                for language_code in self.language_codes:
-                    tasks.append(self.translate_markdown(md_file_path, language_code))
-        await asyncio.gather(*tasks)
+        logger.info("Starting markdown translation tasks...")
 
-    async def process_all_image_files(self):
+        # Step 1: If update is True, delete all existing translated markdown files for the specified languages
+        if update:
+            for language_code in self.language_codes:
+                delete_translated_markdown_files_by_language_code(language_code, self.translations_dir)
+                logger.info(f"Deleted all translated markdown files for language: {language_code}")
+
+        # Step 2: Gather markdown files for translation
+        markdown_files = filter_files(self.root_dir, EXCLUDED_DIRS)
         tasks = []
+
+        for md_file_path in markdown_files:
+            md_file_path = md_file_path.resolve()
+
+            # Check if the file extension is a markdown file
+            if md_file_path.suffix == '.md':
+                for language_code in self.language_codes:
+                    relative_path = md_file_path.relative_to(self.root_dir)
+                    translated_md_path = self.translations_dir / language_code / relative_path
+
+                    if not update and translated_md_path.exists():
+                        logger.info(f"Skipping already translated markdown file: {translated_md_path}")
+                        continue  # Skip to the next markdown file
+
+                    logger.info(f"Translating markdown file: {md_file_path} for language: {language_code}")
+                    tasks.append(self.translate_markdown(md_file_path, language_code))
+
+                    # If tasks reach 5 items, process them asynchronously and update the progress bar
+                    if len(tasks) >= 5:
+                        await tqdm_asyncio.gather(*tasks, total=len(tasks), desc="Translating markdown files")
+                        tasks = []  # Reset tasks list after processing
+
+        # Step 3: Process any remaining tasks
+        if tasks:
+            await tqdm_asyncio.gather(*tasks, total=len(tasks), desc="Translating remaining markdown files")
+        else:
+            logger.info("No markdown translation tasks to run.")
+
+
+    async def translate_all_image_files(self, update=False):
+        """
+        Handles the image translation process. If update is True, it cleans the existing translated files
+        before processing the images. If update is False, it skips translating images that already exist.
+        """
+        logger.info("Starting image translation tasks...")
+
+        # Step 1: If update is True, delete all existing translated images for the specified languages
+        if update:
+            for language_code in self.language_codes:
+                delete_translated_images_by_language_code(language_code, self.image_dir)
+                logger.info(f"Deleted all translated images for language: {language_code}")
+
+        # Step 2: Gather image files for translation
         image_files = filter_files(self.root_dir, EXCLUDED_DIRS)
+        tasks = []
+
         for image_file_path in image_files:
             image_file_path = image_file_path.resolve()
+
+            # Check if the file extension is a supported image format
             if get_filename_and_extension(image_file_path)[1] in SUPPORTED_IMAGE_EXTENSIONS:
                 for language_code in self.language_codes:
-                    tasks.append(self.translate_image(image_file_path, language_code))
-        await asyncio.gather(*tasks)
+                    translated_filename = generate_translated_filename(image_file_path, language_code, self.root_dir)
+                    translated_image_path = Path(self.image_dir) / translated_filename
 
-    async def translate_project_async(self):
+                    # If not updating, skip if the translated image already exists
+                    if not update and translated_image_path.exists():
+                        logger.info(f"Skipping already translated image: {translated_image_path}")
+                        continue  # Skip to the next image file
+
+                    # Translate the image and save it to the output directory
+                    logger.info(f"Translating image: {image_file_path} for language: {language_code}")
+                    tasks.append(self.translate_image(image_file_path, language_code))
+
+                    # If tasks reach 5 items, process them asynchronously and update the progress bar
+                    if len(tasks) >= 5:
+                        await tqdm_asyncio.gather(*tasks, total=len(tasks), desc="Translating images")
+                        tasks = []  # Reset tasks list after processing
+
+        # Process any remaining tasks
+        if tasks:
+            await tqdm_asyncio.gather(*tasks, total=len(tasks), desc="Translating remaining images")
+        else:
+            logger.info("No image translation tasks to run.")
+
+
+
+    async def translate_project_async(self, images=False, markdown=False, update=False):
         """
         Translate the project by processing both markdown and image files asynchronously.
         """
+        logger.info("Starting project translation tasks...")
 
-        logger.info("Resetting translation directories...")
+        # Step 1: Based on flags, process markdown and/or image files
+        tasks = []
         
-        # Step 1: Reset translation directories (remove old, create new)
-        reset_translation_directories(self.translations_dir, self.image_dir, self.language_codes)
+        # If neither images nor markdown is specified, translate both by default
+        if not images and not markdown:
+            images = True
+            markdown = True
+        
+        # Process image translation
+        if images:
+            logger.info(f"Starting image translation tasks (update={update})...")
+            tasks.append(self.translate_all_image_files(update=update))
 
-        # Step 2: Process markdown and image files
-        logger.info("Starting translation tasks...")
-        await asyncio.gather(
-            self.process_all_markdown_files(),
-            self.process_all_image_files()
-        )
+        # Process markdown translation
+        if markdown:
+            logger.info(f"Starting markdown translation tasks (update={update})...")
+            tasks.append(self.translate_all_markdown_files(update=update))
 
-    def translate_project(self):
+        # Step 2: Run tasks asynchronously
+        if tasks:
+            await asyncio.gather(*tasks)
+        else:
+            logger.warning("No tasks to run. Skipping translation.")
+
+    def translate_project(self, images=False, markdown=False, update=False):
         """
         Public method to start the project translation.
         """
-        asyncio.run(self.translate_project_async())
+        asyncio.run(self.translate_project_async(images=images, markdown=markdown, update=update))

--- a/src/co_op_translator/utils/markdown_utils.py
+++ b/src/co_op_translator/utils/markdown_utils.py
@@ -141,9 +141,9 @@ def process_markdown(content: str, max_tokens=4096, encoding='o200k_base') -> li
 
     for i, chunk in enumerate(chunks):
         chunk_tokens = count_tokens(chunk, tokenizer)
-        print(f"Chunk {i+1}: Length = {chunk_tokens} tokens")
+        logger.info(f"Chunk {i+1}: Length = {chunk_tokens} tokens")
         if chunk_tokens == max_tokens:
-            print("Warning: This chunk has reached the maximum token limit.")
+            logger.warning("Warning: This chunk has reached the maximum token limit.")
 
     return chunks
 


### PR DESCRIPTION
## Improved Resilience in Translation Process
- The translation process can now resume from where it left off in the event of an unexpected interruption.
- Since files are only saved once they are fully translated, the system ensures that partially translated files are not left behind, maintaining the integrity of the translation output even when the process is halted.
- This allows users to continue the translation process smoothly without having to restart from the beginning, making the translation process more efficient and robust.

(Solved #21)

### Example:
- If the translation process is stopped midway through, simply rerun the command, and it will pick up from the last completed file instead of restarting from scratch.

```bash
# Resuming from where the process left off after an interruption:
translate -add -l "ko"
```
### Batch image and markdown translation tasks in groups of 5 for efficient async processing.
- Group translation tasks for both images and markdown files into batches of 5 for more efficient asynchronous processing.
- This ensures smoother handling of large sets of files and improves performance in translation tasks.

### Update progress bar in real-time using `tqdm_asyncio.gather` for both images and markdown files.
- The progress bar for image and markdown translation now updates in real-time, showing the progress of translation tasks using `tqdm_asyncio.gather`.
- This enhances visibility during the translation process, providing an accurate status of how many files are being processed and completed.

Here is an example:
```
(.venv) C:\Users\sms79\dev\co_op_translator\src\co_op_translator\test_repo>poetry run translate -l "es" -u
Warning: The update command will delete all existing translations for 'es' and re-translate everything.
Do you want to continue? Type 'yes' to proceed: yes
Proceeding with update...
Translating remaining images: 100%|████████████████████████████████████████████| 3/3 [00:46<00:00, 15.55s/it]
Translating remaining markdown files: 100%|███████████████████████████████████| 1/1 [02:05<00:00, 125.62s/it]
```

### Ensure proper handling of translated files and skipping existing translations when using `--add` mode.
- When using the `--add` mode, the system properly skips files that have already been translated, avoiding redundant translations.
- This improves the efficiency of the translation process, particularly when working with incremental translations.

### Added CLI support for modes: `--add`, `--update`, `--images`, `--markdown`.
- New CLI options are added to control the translation process:
    - `--add`: Adds new translations without deleting existing ones.
    - `--update`: Updates translations by deleting and recreating them.
    - `--images`: Only translate image files.
    - `--markdown`: Only translate markdown files.

### Example Commands
Here are some example commands to demonstrate how the CLI modes can be used:

```bash
# Adds a new translation in Spanish without deleting existing translations
translate -l 'es' --add

# Updates only French markdown files by deleting and re-translating
translate -l 'fr' --update --markdown

# Adds a new translation for Korean images only
translate -l 'ko' --images
